### PR TITLE
Remove boxes category for thecatapi.com

### DIFF
--- a/threesixty/templates/threesixty/thanks.html
+++ b/threesixty/templates/threesixty/thanks.html
@@ -3,7 +3,7 @@
 {% block content %}
     <div class="w3-content">
         <div class="w3-card-4 w3-white w3-center" style="display: inline-block;">
-            <img src="http://thecatapi.com/api/images/get?format=src&type=gif&category=boxes" width="100%">
+            <img src="http://thecatapi.com/api/images/get?format=src&type=gif" width="100%">
             <div class="w3-container w3-center">
                 <p><strong>Thanks!</strong></p>
             </div>


### PR DESCRIPTION
This category always returns a same single gif picture, which is a bit boring.